### PR TITLE
Add release workflow for crates and binary artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Run tests
+        run: cargo test --workspace
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Install cargo-workspaces
+        run: cargo install cargo-workspaces --locked
+      - name: Publish crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          cargo workspaces publish --from-git --no-tag --yes --token $CARGO_REGISTRY_TOKEN
+
+  build:
+    needs: publish
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            archive: spinne-linux.tar.gz
+            build-cmd: cargo build --release --package spinne
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            archive: spinne-macos.tar.gz
+            build-cmd: cargo build --release --package spinne
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            archive: spinne-windows.zip
+            build-cmd: cargo build --release --package spinne
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Build binary
+        run: ${{ matrix.build-cmd }}
+      - name: Package binary
+        shell: bash
+        run: |
+          mkdir dist
+          if [[ "${{ matrix.os }}" == 'windows-latest' ]]; then
+            cp target/release/spinne.exe dist/
+            cd dist && zip ../${{ matrix.archive }} spinne.exe
+          else
+            cp target/release/spinne dist/
+            cd dist && tar -czf ../${{ matrix.archive }} spinne
+          fi
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.archive }}
+          path: ${{ matrix.archive }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Determine version
+        id: version
+        run: echo "version=$(grep '^version' crates/cli/Cargo.toml | head -n1 | cut -d '"' -f2)" >> $GITHUB_OUTPUT
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: dist
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.version.outputs.version }}
+          name: v${{ steps.version.outputs.version }}
+          files: dist/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- automate publishing crates on merge to `main`
- build binaries for Linux, macOS and Windows
- create a GitHub release with attached binaries

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_68405bb16cbc8329a6dec324fa177e00